### PR TITLE
Handle errors in unsexpify

### DIFF
--- a/xapitodict/lib.py
+++ b/xapitodict/lib.py
@@ -69,7 +69,11 @@ def unsexpify(v):
         val = v.replace("'", '"')
         # Let's unprotect spaces and other characters
         val = unprotect(val)
-        return sexpdata.loads(val)
+        try:
+            return sexpdata.loads(val)
+        except AssertionError:
+            # If it doesn't load as a sexp it probably isn't one.
+            pass
 
     # it's a simple string, remove unnecessary `'`
     val = v.strip("'")


### PR DESCRIPTION
We had database where a name field started with ( and this tripped
into the sexp decode which then hit an assertion as it wasn't really
a sexp.

  | .../sexpdata.py", line 244, in loads
  |    assert len(obj) == 1  # FIXME: raise an appropriate error

In this case fallback to treating it as a simple string.

Signed-off-by: Mark Syms <mark.syms@citrix.com>